### PR TITLE
Update Media-User-Token cookie to uppercase

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,7 +39,7 @@ class RenderCard:
         headers = {
             "Authorization": f"Bearer {self.__token}",
             "Cookie": self.__cookie,
-            "media-user-token": self.__media_user_token,
+            "Media-User-Token": self.__media_user_token,
             "origin": "https://music.apple.com",
             "referer": "https://music.apple.com/",
         }


### PR DESCRIPTION
Hi,
First thanks for taking the time to develop this little app. Apple changed the header for the user token from "media-user-token" to "Media-User-Token".  To stay up to date with this change, the request headers needs to be updated too. This PR seems to fix the issue. 